### PR TITLE
netdev-group support for Juniper device.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,7 +23,7 @@ Metrics/AbcSize:
   Enabled: false
 PerceivedComplexity:
   Enabled: false
-SingleSpaceBeforeFirstArg:
+SpaceBeforeFirstArg:
   Enabled: false
 Style/ClassAndModuleChildren:
   Enabled: false

--- a/Berksfile
+++ b/Berksfile
@@ -7,4 +7,5 @@ group :integration, :test do
   cookbook 'l2_interface', path: 'test/fixtures/cookbooks/l2_interface'
   cookbook 'lag',          path: 'test/fixtures/cookbooks/lag'
   cookbook 'vlan',         path: 'test/fixtures/cookbooks/vlan'
+  cookbook 'group',        path: 'test/fixtures/cookbooks/group'
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,27 @@ Features:
 Improvements:
   - Converted all LWRPs to HWRPs
   - Rubocop style checking
+
+v2.1.0 (2016-03-11)
+-------------------
+Features:
+- Add netdev_group provider for Juniper devices
+- Add support for Juniper devices running BSD10 based JUNOS images
+
+Bug fix:
+  - Issue 7 ArgumentError: wrong number of arguments(2 for 0) error is coming while running chef for 
+            occam device.
+  - Issue 9 Chef client run throws error on JUNOS device when it is triggered second time.
+  - Issue 10 Chef client run fails with "Netconf IO timed out while waiting for more data" error on 
+             JUNOS MX device.
+  - Issue 11 For netdev_group resource action :delete is not working as expected on a specific scenario 
+             while invoking the template based chef recipe.
+  - Issue 12 Chef client run fails while configuring interface with speed 10m on MX device.
+  - Issue 13 Configuration database is not open Error is thrown if same recipe is invoked 
+             again via Chef JUNOS Client.
+  - Issue 14 TypeError: can't convert nil into String is thrown if the JUNOS configuration 
+             format mentioned in the template file is invalid.
+  - Issue 15 Chef is not throwing the proper warning message while deleting a netdev_group which 
+             is protected.
+  - Issue 18 If apply-group configuration it deleted, it is not configured during second Chef client run.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ Improvements:
 v2.1.0 (2016-03-11)
 -------------------
 Features:
-- Add netdev_group provider for Juniper devices
-- Add support for Juniper devices running BSD10 based JUNOS images
+- Add netdev_group provider for Juniper devices.
+- Add support for Juniper devices running BSD10 based JUNOS images.
+- Add support for MX series Juniper device.
 
 Bug fix:
   - Issue 7 ArgumentError: wrong number of arguments(2 for 0) error is coming while running chef for 

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'junos-ez-stdlib', git: 'https://github.com/Juniper/ruby-junos-ez-stdlib.git',
-                       tag: 'v0.2.0_20130819_1'
+                       tag: '1.0.0'
 
 group :lint do
   gem 'foodcritic', '~> 5.0'

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ __netdev_interface__ | This resource provides an abstraction for managing physic
 __netdev\_l2\_interface__ | This resource provides an abstraction for creating and deleting layer 2 interfaces on network devices. | [netdev_l2_interface integation test fixture](test/fixtures/cookbooks/l2_interface/recipes/create.rb).
 __netdev\_lag__ | This resource provides an abstraction for creating and deleting link aggregation group interfaces. | [netdev_lag integation test fixture](test/fixtures/cookbooks/lag/recipes/create.rb).
 __netdev\_vlan__ | This resource provides an abstraction for creating and deleting VLANs. | [netdev_vlan integation test fixture](test/fixtures/cookbooks/vlan/recipes/create.rb).
+__netdev\_group__ | This resource provides an abstraction for creating and deleting JUNOS Groups. | [netdev_group integation test fixture](test/fixtures/cookbooks/group/recipes/service_create.rb).
 
 Testing
 -------

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require 'bundler/setup'
 namespace :style do
   require 'rubocop/rake_task'
   desc 'Run Ruby style checks'
-  Rubocop::RakeTask.new(:ruby)
+  RuboCop::RakeTask.new(:ruby)
 end
 
 desc 'Run all style checks'

--- a/libraries/_junos_api_client.rb
+++ b/libraries/_junos_api_client.rb
@@ -18,7 +18,7 @@ begin
   require 'junos-ez/stdlib'
   require 'net/netconf/exception'
 rescue LoadError
-  msg  = 'Could not load the junos-ez-stdlib gem...'
+  msg = 'Could not load the junos-ez-stdlib gem...'
   msg << 'ensure you are using the Chef for Junos packages'
   Chef::Log.debug msg
 end
@@ -37,7 +37,8 @@ module Netdev
           l2_ports: ::Junos::Ez::L2ports,
           ip_ports: ::Junos::Ez::IPports,
           vlans: ::Junos::Ez::Vlans,
-          lag_ports: ::Junos::Ez::LAGports
+          lag_ports: ::Junos::Ez::LAGports,
+          group: ::Junos::Ez::Group
         }
 
         KNOWN_RESOURCES.each_pair do |resource, provider_module|
@@ -170,6 +171,7 @@ module Netdev
       def with_config_check(&_block)
         # ensure a transaction has been opened
         transport.start_transaction! unless transport.transaction_open?
+        Netconf::raise_on_warning = true
 
         yield
 
@@ -178,8 +180,18 @@ module Netdev
           Chef::Log.debug("#{self} validated Junos candidate configuration")
         end
       rescue Netconf::RpcError => e
-        Chef::Log.error(format_rpc_error(e))
-        raise e
+        rpc_errs = e.rsp.xpath('//rpc-error')
+        if rpc_errs
+          all_count = rpc_errs.count
+          warn_count = rpc_errs.xpath('error-severity').select{ |err| err.text == 'warning' }.count
+          if all_count - warn_count > 0
+            Chef::Log.error("#{self} error communicating with the Junos XML API...rolling back!")
+            Chef::Log.error(format_rpc_error(e))
+            raise e
+          elsif warn_count
+            Chef::Log.info(format_rpc_error(e))
+          end
+        end
       end
 
       # Takes a `Netconf::RpcError` and extracts the request and response
@@ -207,7 +219,6 @@ module Netdev
         end
 
         error_msg = <<-MSG
-  #{self} error communicating with the Junos XML API...rolling back!
 
   JUNOS XML REQUEST:
 

--- a/libraries/_junos_api_transport.rb
+++ b/libraries/_junos_api_transport.rb
@@ -23,7 +23,7 @@ begin
   require 'net/netconf/jnpr/ioproc'
   require 'junos-ez/stdlib'
 rescue LoadError
-  msg  = 'Could not load the junos-ez-stdlib gem...'
+  msg = 'Could not load the junos-ez-stdlib gem...'
   msg << 'ensure you are using the Chef for Junos packages'
   Chef::Log.debug msg
 end
@@ -53,6 +53,7 @@ module Netdev
       def_delegator :@transport_config, :commit?
       def_delegator :@transport_config, :commit!
       def_delegator :@transport_config, :rollback!
+      def_delegator :@transport_rpc, :get_configuration
 
       # Creates a fully-initialized Netconf transport instance for
       # communicating with the Junos XML API. Currently we only support
@@ -78,25 +79,30 @@ module Netdev
         opts = {}
         opts[:comment] = commit_log_comment if commit_log_comment
         # commit the candidate configuration
-        @transport_config.commit!(opts)
-        Chef::Log.info('Committed pending Junos candidate configuration changes')
-        # release the exclusive lock on the configuration
-        @transport_config.unlock!
-        Chef::Log.info('Released exclusive Junos configuration lock')
-        @transaction_open = false
+        if @transaction_open
+          @transport_config.commit!(opts)
+          Chef::Log.info('Committed pending Junos candidate configuration changes')
+          # release the exclusive lock on the configuration
+          @transport_config.unlock!
+          Chef::Log.info('Released exclusive Junos configuration lock')
+          @transaction_open = false
+        else
+          Chef::Log.debug("#{self}: Nothing to commit !! ")
+        end
       end
 
       private
 
       def open_connection!
         # Create a connection to the NETCONF service
-        @transport = Netconf::IOProc.new
+        @transport = Netconf::IOProc.new(Hash[timeout: 600])
         @transport.open
 
         # enable basic Junos EZ Stdlib providers
         ::Junos::Ez::Provider(@transport)
         ::Junos::Ez::Config::Utils(@transport, :config)
         @transport_config = @transport.config
+        @transport_rpc = @transport.rpc
 
         ApiClient::KNOWN_RESOURCES.each_pair do |resource, provider_module|
           provider_module.send(:Provider, @transport, resource)

--- a/libraries/platform_provider_mapping.rb
+++ b/libraries/platform_provider_mapping.rb
@@ -24,6 +24,7 @@ require_relative 'provider_lag_eos'
 require_relative 'provider_lag_junos'
 require_relative 'provider_vlan_eos'
 require_relative 'provider_vlan_junos'
+require_relative 'provider_group_junos'
 
 #########################################################################
 # Chef::Resource::NetdevInterface Providers
@@ -36,6 +37,12 @@ Chef::Platform.set(
 
 Chef::Platform.set(
   platform: :junos,
+  resource: :netdev_interface,
+  provider: Chef::Provider::NetdevInterface::Junos
+)
+
+Chef::Platform.set(
+  version:  'JNPR',
   resource: :netdev_interface,
   provider: Chef::Provider::NetdevInterface::Junos
 )
@@ -55,6 +62,12 @@ Chef::Platform.set(
   provider: Chef::Provider::NetdevL2Interface::Junos
 )
 
+Chef::Platform.set(
+  version: 'JNPR',
+  resource: :netdev_l2_interface,
+  provider: Chef::Provider::NetdevL2Interface::Junos
+)
+
 #########################################################################
 # Chef::Resource::NetdevLinkAggregationGroup Providers
 #########################################################################
@@ -66,6 +79,12 @@ Chef::Platform.set(
 
 Chef::Platform.set(
   platform: :junos,
+  resource: :netdev_lag,
+  provider: Chef::Provider::NetdevLinkAggregationGroup::Junos
+)
+
+Chef::Platform.set(
+  version: 'JNPR',
   resource: :netdev_lag,
   provider: Chef::Provider::NetdevLinkAggregationGroup::Junos
 )
@@ -83,4 +102,25 @@ Chef::Platform.set(
   platform: :junos,
   resource: :netdev_vlan,
   provider: Chef::Provider::NetdevVirtualLAN::Junos
+)
+
+Chef::Platform.set(
+  version: 'JNPR',
+  resource: :netdev_vlan,
+  provider: Chef::Provider::NetdevVirtualLAN::Junos
+)
+
+#########################################################################
+# Chef::Resource::NetdevGroup Providers
+#########################################################################
+Chef::Platform.set(
+  platform: :junos,
+  resource: :netdev_group,
+  provider: Chef::Provider::NetdevGroup::Junos
+)
+
+Chef::Platform.set(
+  version: 'JNPR',
+  resource: :netdev_group,
+  provider: Chef::Provider::NetdevGroup::Junos
 )

--- a/libraries/provider_group_junos.rb
+++ b/libraries/provider_group_junos.rb
@@ -1,0 +1,119 @@
+#
+# Cookbook Name:: netdev
+# Provider:: group
+#
+# Copyright 2014, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/resource'
+require 'chef/provider'
+
+require_relative '_helper'
+require_relative '_junos_api_client'
+require_relative 'resource_group'
+
+class Chef
+  class Provider::NetdevGroup::Junos < Provider
+    include Netdev::Helper
+
+    #
+    # This provider supports why-run mode.
+    #
+    def whyrun_supported?
+      true
+    end
+
+    def load_current_resource
+      @current_resource = Chef::Resource::NetdevGroup.new(new_resource.name)
+      @current_resource.group_name(new_resource.group_name)
+
+      # Check if apply-group is configured
+      apply_grp_config = Netdev::Junos::ApiTransport.instance.get_configuration{ |a_grp|
+        a_grp.send('apply-groups')
+      }
+      apply_grp = apply_grp_config.xpath("//apply-groups=\'#{new_resource.group_name}\'")
+
+      if (group = junos_client.managed_resource) && group.exists? && apply_grp
+        @current_resource.exists = true
+      else
+        @current_resource.exists = false
+      end
+      @file_path = "/var/tmp/#{new_resource.name}"
+      @new_values = new_resource.state
+      @current_values = current_resource.state
+
+      @template_resource = Chef::Resource::Template.new(@file_path, run_context)
+      @template_resource.source(@new_values[:template_path])
+      @template_resource.cookbook(new_resource.cookbook_name)
+      @template_resource.variables(@new_values[:variables])
+      @template_resource.run_action(@action)
+      @is_resource_updated = @template_resource.updated_by_last_action?
+      @current_resource
+    end
+
+    #
+    # Create the given group.
+    #
+    def action_create
+      unless @is_resource_updated || !@current_resource.exists
+        Chef::Log.info('Configuration file is same. Nothing to commit.')
+        return
+      end
+      @new_values[:path] = @file_path
+      format = @new_values[:template_path].split('/')[-1].split('.')
+      if format[1] != 'erb'
+        unless %w(xml text set).include? format[1]
+          failure_msg = "Invalid format #{format[1]} in #{@new_values[:template_path]}. Valid format values: 'xml', 'text', 'set'.\n\n"
+          Chef::Log.fatal(failure_msg)
+          raise(failure_msg)
+        end
+
+        @new_values[:format] = format[1]
+      else
+        @new_values[:format] = 'xml'
+      end
+
+      @new_values.delete(:template_path)
+      @current_values.delete(:template_path)
+      @new_values.delete(:variables)
+      @current_values.delete(:variables)
+      updated_values = junos_client.updated_changed_properties(@new_values,
+                                                               @current_values)
+      unless updated_values.empty?
+        message = "create JUNOS group #{new_resource.name} and apply it."
+        converge_by(message) do
+          junos_client.write!
+        end
+      end
+    end
+
+    #
+    # Delete the given group.
+    #
+    def action_delete
+      if current_resource.exists?
+        converge_by("delete JUNOS group #{new_resource.name}") do
+          junos_client.delete!
+        end
+      end
+    end
+
+    private
+
+    def junos_client
+      @junos_client ||= Netdev::Junos::ApiClient::Group.new(new_resource.group_name)
+    end
+  end
+end

--- a/libraries/resource_group.rb
+++ b/libraries/resource_group.rb
@@ -1,0 +1,90 @@
+#
+# Cookbook Name:: netdev
+# Resource:: JUNOS apply group
+#
+# Copyright 2014, Chef Software, Inc.
+# Copyright 2015, Juniper Network.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/resource'
+require 'chef/provider'
+
+class Chef
+  class Resource::NetdevGroup < Resource
+    provides      :netdev_group
+    identity_attr :group_name
+    state_attrs   :template_path, :variables
+
+    attr_accessor :exists
+    alias_method  :exists?, :exists
+
+    def initialize(name, run_context = nil)
+      super
+
+      @resource_name = :netdev_group
+
+      # Set default actions and allowed actions
+      @action = :create
+      @allowed_actions.push(:create, :delete)
+
+      # Set the name attribute and default attributes
+      @group_name      = name
+
+      @enable          = true
+
+      # State attributes that are set by the provider
+      @exists          = false
+    end
+
+    #
+    # The name of the JUNOS Group.
+    #
+    # @param [String] arg
+    # @return [String]
+    #
+    def group_name(arg = nil)
+      set_or_return(:group_name, arg, kind_of: String)
+    end
+
+    #
+    # The variables to template.
+    #
+    # @param [HASH] arg
+    # @return [HASH]
+    #
+    def variables(args = nil)
+      set_or_return(
+        :variables,
+        args,
+        kind_of: [Hash]
+      )
+    end
+
+    #
+    # The JUNOS configuration template path.
+    #
+    # @param [String] arg
+    # @return [String]
+    #
+    def template_path(arg = nil)
+      set_or_return(
+        :template_path,
+        arg,
+        kind_of: String
+      )
+    end
+  end
+end
+class Chef::Provider::NetdevGroup; end

--- a/libraries/resource_interface.rb
+++ b/libraries/resource_interface.rb
@@ -102,7 +102,7 @@ class Chef
         :speed,
         arg,
         kind_of: String,
-        equal_to: %w( auto 100m 1g 10g 40g 56g 100g )
+        equal_to: %w( auto 10m 100m 1g 10g 40g 56g 100g )
       )
     end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'releng@chef.io'
 license          'Apache 2.0'
 description      'Provides a set of vendor-neutral resources for managing networking devices'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.0.0'
+version          '2.1.0'
 
 source_url 'https://github.com/chef-partners/netdev' if respond_to?(:source_url)
 issues_url 'https://github.com/chef-partners/netdev/issues' if respond_to?(:issues_url)

--- a/spec/unit/provider/group/junos_spec.rb
+++ b/spec/unit/provider/group/junos_spec.rb
@@ -1,0 +1,55 @@
+#
+# Copyright 2014, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe Chef::Provider::NetdevGroup::Junos do
+  include_context 'provider_junos'
+
+  let(:managed_resource) do
+    grp = double('service_group', exists?: true)
+    allow(grp).to receive(:[]).with(:template_path) { 'services.set.erb' }
+    allow(grp).to receive(:[]).with(:_active) { true }
+    grp
+  end
+
+  let(:new_resource) do
+    new_resource = Chef::Resource::NetdevGroup.new('service_group')
+    new_resource.template_path('services.set.erb')
+    new_resource.variables(services: node[:netdev][:services])
+    new_resource
+  end
+
+  describe '#action_create' do
+    it 'creates the group if properties have changed' do
+      junos_client.should_receive(:updated_changed_properties).and_return({})
+      junos_client.should_receive(:write!).with(no_args)
+      provider.run_action(:create)
+    end
+
+    it 'does nothing if properties are unchanged' do
+      junos_client.should_receive(:updated_changed_properties).and_return({})
+      provider.run_action(:create)
+    end
+  end
+
+  describe '#action_delete' do
+    it 'deletes the group' do
+      junos_client.should_receive(:delete!).with(no_args)
+      provider.run_action(:delete)
+    end
+  end
+end

--- a/test/fixtures/cookbooks/group/attributes/default.rb
+++ b/test/fixtures/cookbooks/group/attributes/default.rb
@@ -1,0 +1,6 @@
+default[:netdev][:services] = [%w(ftp), %w(ssh), %w(netconf, ssh)]
+default[:netdev][:bgp] = { 'internal' => { 'type' => 'internal', 'neighbor' => ['10.10.10.10', '10.10.10.11'], 'local-address' => '20.20.20.20', 'peer-as' => '100' },
+                           'external' => { 'type' => 'external', 'neighbor' => ['30.30.10.10', '30.30.10.11'], 'local-address' => '20.20.20.20', 'peer-as' => '200' } }
+
+default[:netdev][:syslog] = { 'messages' => [{ 'facility' => 'any', 'level' => 'critical' }, { 'facility' => 'authorization', 'level' => 'info' }],
+                              'interactive-commands' => [{ 'facility' => 'interactive-commands', 'level' => 'error' }] }

--- a/test/fixtures/cookbooks/group/metadata.rb
+++ b/test/fixtures/cookbooks/group/metadata.rb
@@ -1,0 +1,2 @@
+name    'group'
+depends 'netdev'

--- a/test/fixtures/cookbooks/group/recipes/bgp_create.rb
+++ b/test/fixtures/cookbooks/group/recipes/bgp_create.rb
@@ -1,0 +1,5 @@
+netdev_group 'bgp_group' do
+  template_path 'bgp.xml.erb'
+  action :create
+  variables(bgp: node[:netdev][:bgp])
+end

--- a/test/fixtures/cookbooks/group/recipes/bgp_delete.rb
+++ b/test/fixtures/cookbooks/group/recipes/bgp_delete.rb
@@ -1,0 +1,4 @@
+netdev_group 'bgp_group' do
+  template_path 'bgp.xml.erb'
+  action :delete
+end

--- a/test/fixtures/cookbooks/group/recipes/service_create.rb
+++ b/test/fixtures/cookbooks/group/recipes/service_create.rb
@@ -1,0 +1,5 @@
+netdev_group 'service_group' do
+  template_path 'services.set.erb'
+  action :create
+  variables(services: node[:netdev][:services])
+end

--- a/test/fixtures/cookbooks/group/recipes/service_delete.rb
+++ b/test/fixtures/cookbooks/group/recipes/service_delete.rb
@@ -1,0 +1,4 @@
+netdev_group 'service_group' do
+  template_path 'services.set.erb'
+  action :delete
+end

--- a/test/fixtures/cookbooks/group/recipes/syslog_create.rb
+++ b/test/fixtures/cookbooks/group/recipes/syslog_create.rb
@@ -1,0 +1,5 @@
+netdev_group 'syslog_group' do
+  template_path 'syslog.text.erb'
+  action :create
+  variables(syslog_names: node[:netdev][:syslog])
+end

--- a/test/fixtures/cookbooks/group/recipes/syslog_delete.rb
+++ b/test/fixtures/cookbooks/group/recipes/syslog_delete.rb
@@ -1,0 +1,4 @@
+netdev_group 'syslog_group' do
+  template_path 'syslog.text.erb'
+  action :delete
+end

--- a/test/fixtures/cookbooks/group/templates/junos/bgp.xml.erb
+++ b/test/fixtures/cookbooks/group/templates/junos/bgp.xml.erb
@@ -1,0 +1,18 @@
+<% @bgp.each do | name, hash | %>
+            <protocols>
+                <bgp>
+                    <group>
+                        <name><%=name%></name>
+                        <type><%= hash['type']%></type>
+                        <local-address><%= hash['local-address']%></local-address>
+                        <% hash['neighbor'].each do | neighbor | %>
+                        <neighbor>
+                            <name><%=neighbor%></name>
+                        </neighbor>
+                         <% end %>
+                        <peer-as><%= hash['peer-as']%></peer-as>
+                    </group>
+                </bgp>
+            </protocols>
+<% end %>
+

--- a/test/fixtures/cookbooks/group/templates/junos/services.set.erb
+++ b/test/fixtures/cookbooks/group/templates/junos/services.set.erb
@@ -1,0 +1,3 @@
+<% @services.each do | service | %>
+set system services <%= service[0] %> <%= service[1] %>
+<% end %>

--- a/test/fixtures/cookbooks/group/templates/junos/syslog.text.erb
+++ b/test/fixtures/cookbooks/group/templates/junos/syslog.text.erb
@@ -1,0 +1,11 @@
+system {
+    syslog {
+    <% @syslog_names.each do | name, details | %>
+    	<% details.each do | detail | %>
+		file <%= name %> {
+             		<%= detail['facility'] %> <%= detail['level'] %>
+ 		}
+        <% end %>
+    <% end %> 
+    }
+}

--- a/test/integration/group/serverspec/group_create_spec.rb
+++ b/test/integration/group/serverspec/group_create_spec.rb
@@ -1,0 +1,13 @@
+require 'serverspec'
+require 'pathname'
+
+include Serverspec::Helper::Exec
+include Serverspec::Helper::DetectOS
+
+describe command('cli show config groups service_group') do
+  it { should return_stdout(/system/) }
+end
+
+describe command('cli show config apply-groups') do
+  it { should_not return_stdout(/\s.*apply-groups \s.* service_group\s.*/) }
+end


### PR DESCRIPTION
Features:
```
Add netdev_group provider for Juniper devices.
Add support for Juniper devices running BSD10 based JUNOS images.
Add support for MX series Juniper device.
```

Bug fix:
```
Issue 7 ArgumentError: wrong number of arguments(2 for 0) error is coming while running chef for occam device.
Issue 9 Chef client run throws error on JUNOS device when it is triggered second time.
Issue 10 Chef client run fails with "Netconf IO timed out while waiting for more data" error on JUNOS MX device.
Issue 11 For netdev_group resource action :delete is not working as expected on a specific scenario while invoking the template based chef recipe.
Issue 12 Chef client run fails while configuring interface with speed 10m on MX device.
Issue 13 Configuration database is not open Error is thrown if same recipe is invoked again via Chef JUNOS Client.
Issue 14 TypeError: can't convert nil into String is thrown if the JUNOS configuration format mentioned in the template file is invalid.
Issue 15 Chef is not throwing the proper warning message while deleting a netdev_group which is protected.
Issue 18 If apply-group configuration it deleted, it is not configured during second Chef client run.
```